### PR TITLE
Db folder compilation typo

### DIFF
--- a/barApp/Db/Makefile
+++ b/barApp/Db/Makefile
@@ -9,6 +9,6 @@ include $(TOP)/configure/CONFIG
 DB+=NDBar.template
 
 
-include$(TOP)/configure/RULES
+include $(TOP)/configure/RULES
 
 #add rules here


### PR DESCRIPTION
The typo in Makefile was preventing compilation of the Db folder.