### PR TITLE
compilation of zbar

### DIFF
--- a/barApp/barSrc/Makefile
+++ b/barApp/barSrc/Makefile
@@ -25,12 +25,16 @@ NDPluginBar_SRCS += NDPluginBar.cpp
 # g++ test.cpp $(pkg-config --libs opencv --cflags) $(pkg-config --libs zbar --cflags) -o check
 #Must link Opencv and zbar libraries here
 
-USR_INCLUDES += -I$(OPENCV_INCLUDE)
+ifdef OPENCV_INCLUDE
+  USR_INCLUDES += -I$(OPENCV_INCLUDE)
+endif 
 ifdef OPENCV_LIB
   NDPluginBar_DIR += $(OPENCV_LIB)
 endif
 
-USR_INCLUDES += -I$(ZBAR_INCLUDE)
+ifdef ZBAR_INCLUDE
+  USR_INCLUDES += -I$(ZBAR_INCLUDE)
+endif 
 ifdef ZBAR_LIB
   NDPluginBar_DIR += $(ZBAR_LIB)
 endif


### PR DESCRIPTION
kaz@xf10id-is1:/epics/synApps/support/areaDetector-3-2/ADPluginBar/barApp/barSrc$ make
perl -CSD /epics/base-7-0-1-1/bin/linux-x86_64/makeMakefile.pl O.linux-x86_64 ../../..
mkdir -p O.Common
make -C O.linux-x86_64 -f ../Makefile TOP=../../.. \

    T_A=linux-x86_64 install
    
make[1]: Entering directory '/epics/synApps/support/areaDetector-3-2/ADPluginBar/barApp/barSrc/O.linux-x86_64'

/usr/bin/g++  -D_GNU_SOURCE -D_DEFAULT_SOURCE           -D_X86_64_  -DUNIX  -Dlinux     -O3 -g   -Wall      -mtune=generic     -m64 -fPIC -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/Linux -I../../../include      -I/epics/synApps/support/asyn-4-33/include     -I/epics/synApps/support/areaDetector-3-2/ADSupport/include/os/Linux -I/epics/synApps/support/areaDetector-3-2/ADSupport/include   -I/epics/synApps/support/areaDetector-3-2/ADCore/include -I/epics/base-7-0-1-1/include/compiler/gcc -I/epics/base-7-0-1-1/include/os/Linux -I/epics/base-7-0-1-1/include     -I    -MM -MF NDPluginBar.d  ../NDPluginBar.cpp

cc1plus: error: to generate dependencies you must specify either -M or -MM

Installing dbd file ../../../dbd/NDPluginBar.dbd
==================
barApp/barSrc/Makefile
@@ -25,12 +25,16 @@ NDPluginBar_SRCS += NDPluginBar.cpp
 # g++ test.cpp $(pkg-config --libs opencv --cflags) $(pkg-config --libs zbar --cflags) -o check
 #Must link Opencv and zbar libraries here
 
-USR_INCLUDES += -I$(OPENCV_INCLUDE)
+ifdef OPENCV_INCLUDE
+  USR_INCLUDES += -I$(OPENCV_INCLUDE)
+endif 
 ifdef OPENCV_LIB
   NDPluginBar_DIR += $(OPENCV_LIB)
 endif
 
-USR_INCLUDES += -I$(ZBAR_INCLUDE)
+ifdef ZBAR_INCLUDE
+  USR_INCLUDES += -I$(ZBAR_INCLUDE)
+endif 
 ifdef ZBAR_LIB
   NDPluginBar_DIR += $(ZBAR_LIB)
 endif
===============
Without that change if OPENCV_INCLUDE is not defined then the gcc command has a -I with no directory following it.  gcc then uses the next flag (-MM or -c in your case) and consumes them with -I.  That is what is causing those strange errors.
Same happens without change if ABAR_INCLUDE is not defined.

