### PR TITLE
Fix corrupt file that crashed autosave during ioc start

### DIFF
--- a/barApp/Db/NDBar_settings.req
+++ b/barApp/Db/NDBar_settings.req
@@ -1,1 +1,2 @@
+# Nothing extra needed beyond NDPluginBase_settings.req for now
 file "NDPluginBase_settings.req", P=$(P), R=$(R)


### PR DESCRIPTION
There was some corruption in the file that was crashing autosave during ioc startup.
The diff did not catch it, but it seems that github shows some special character at the end of the line that was in the prior file.

